### PR TITLE
Removed duplicated entry tag.

### DIFF
--- a/root/contrib/install_mod_update_2012.11.27.01-2012.12.10.01.xml
+++ b/root/contrib/install_mod_update_2012.11.27.01-2012.12.10.01.xml
@@ -55,7 +55,6 @@
                         </changelog>
                     </entry>
 				<entry>
-				<entry>
                         <date>2012.11.27</date>
                         <rev-version>2012.11.27.01</rev-version>
                         <changelog lang="en">


### PR DESCRIPTION
Removed duplicated entry tag which causes errors when browsing
changelog in AutoMOD.

Signed-off-by: Lukasz Gromanowski lgromanowski@gmail.com
